### PR TITLE
Add startup management functionality to the application

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from src.services.notification_service import NotificationService
 from src.ui.snipping_tool import TkinterSnippingTool
 from src.ui.tray_icon import TrayIconManager
 from src.utils.exceptions import handle_exception
+from src.utils.startup_manager import set_startup_registry, is_startup_enabled
 import threading
 import sys
 import keyboard
@@ -33,7 +34,9 @@ class QRCodeDetectionApp:
             self.notification_service,
         )
         self.tray_icon_manager: TrayIconManager = TrayIconManager(
-            self.snipping_tool.create_screen_canvas
+            self.snipping_tool.create_screen_canvas,
+            set_startup_registry,
+            is_startup_enabled,
         )
 
     def listen_for_shortcut(self) -> None:

--- a/src/utils/startup_manager.py
+++ b/src/utils/startup_manager.py
@@ -5,11 +5,13 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def get_app_path() -> str:
     """Get the path to the executable or script"""
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, "frozen", False):
         return sys.executable
     return os.path.abspath(sys.argv[0])
+
 
 def set_startup_registry(enable: bool) -> bool:
     """Set or remove the application from Windows startup registry"""
@@ -19,7 +21,7 @@ def set_startup_registry(enable: bool) -> bool:
             winreg.HKEY_CURRENT_USER,
             r"Software\Microsoft\Windows\CurrentVersion\Run",
             0,
-            winreg.KEY_SET_VALUE | winreg.KEY_QUERY_VALUE
+            winreg.KEY_SET_VALUE | winreg.KEY_QUERY_VALUE,
         )
 
         if enable:
@@ -29,12 +31,13 @@ def set_startup_registry(enable: bool) -> bool:
                 winreg.DeleteValue(key, "QRGrabber")
             except FileNotFoundError:
                 pass
-        
+
         winreg.CloseKey(key)
         return True
     except Exception as e:
         logger.error(f"Failed to modify startup registry: {e}")
         return False
+
 
 def is_startup_enabled() -> bool:
     """Check if the application is set to run at startup"""
@@ -43,7 +46,7 @@ def is_startup_enabled() -> bool:
             winreg.HKEY_CURRENT_USER,
             r"Software\Microsoft\Windows\CurrentVersion\Run",
             0,
-            winreg.KEY_READ
+            winreg.KEY_READ,
         )
         try:
             winreg.QueryValueEx(key, "QRGrabber")

--- a/src/utils/startup_manager.py
+++ b/src/utils/startup_manager.py
@@ -25,7 +25,8 @@ def set_startup_registry(enable: bool) -> bool:
         )
 
         if enable:
-            winreg.SetValueEx(key, "QRGrabber", 0, winreg.REG_SZ, f'"{app_path}"')
+            escaped_path = app_path.strip('"')  # Remove existing quotes if present
+            winreg.SetValueEx(key, "QRGrabber", 0, winreg.REG_SZ, f'"{escaped_path}"')
         else:
             try:
                 winreg.DeleteValue(key, "QRGrabber")

--- a/src/utils/startup_manager.py
+++ b/src/utils/startup_manager.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import winreg
+import logging
+
+logger = logging.getLogger(__name__)
+
+def get_app_path() -> str:
+    """Get the path to the executable or script"""
+    if getattr(sys, 'frozen', False):
+        return sys.executable
+    return os.path.abspath(sys.argv[0])
+
+def set_startup_registry(enable: bool) -> bool:
+    """Set or remove the application from Windows startup registry"""
+    try:
+        app_path = get_app_path()
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Run",
+            0,
+            winreg.KEY_SET_VALUE | winreg.KEY_QUERY_VALUE
+        )
+
+        if enable:
+            winreg.SetValueEx(key, "QRGrabber", 0, winreg.REG_SZ, f'"{app_path}"')
+        else:
+            try:
+                winreg.DeleteValue(key, "QRGrabber")
+            except FileNotFoundError:
+                pass
+        
+        winreg.CloseKey(key)
+        return True
+    except Exception as e:
+        logger.error(f"Failed to modify startup registry: {e}")
+        return False
+
+def is_startup_enabled() -> bool:
+    """Check if the application is set to run at startup"""
+    try:
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Run",
+            0,
+            winreg.KEY_READ
+        )
+        try:
+            winreg.QueryValueEx(key, "QRGrabber")
+            return True
+        except FileNotFoundError:
+            return False
+        finally:
+            winreg.CloseKey(key)
+    except Exception:
+        return False


### PR DESCRIPTION
This PR addresses Issue #3

## Summary by Sourcery

Add startup management functionality to the application, allowing users to enable or disable the application running at startup through the system tray menu. Implement utility functions to manage Windows startup registry settings.

New Features:
- Introduce startup management functionality allowing the application to be set to run at startup via the system tray menu.

Enhancements:
- Add a toggle option in the system tray menu to enable or disable application startup.